### PR TITLE
removed unnecessary check for having a parent PerfectScrollbarModule

### DIFF
--- a/src/perfect-scrollbar.module.ts
+++ b/src/perfect-scrollbar.module.ts
@@ -14,13 +14,6 @@ export const PERFECT_SCROLLBAR_CONFIG = new OpaqueToken('PERFECT_SCROLLBAR_CONFI
     exports: [CommonModule, PerfectScrollbarComponent]
 })
 export class PerfectScrollbarModule {
-  constructor (@Optional() @SkipSelf() parentModule: PerfectScrollbarModule) {
-    if (parentModule) {
-      throw new Error(`PerfectScrollbarModule is already loaded. 
-        Import it in the AppModule only!`);
-    }
-  }
-
   static forRoot(config: PerfectScrollbarConfigInterface): ModuleWithProviders {
     return {
       ngModule: PerfectScrollbarModule,


### PR DESCRIPTION
Since your module doesn't contain a service, just a component, why check if there is already a parent module loaded?

Or am I missing something?

This would fix #2 
