### PR TITLE
add short explanation to readme on component use

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ const PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = {
 
 ##### Use it in your html template (with custom configuration):
 
-```html
-<perfect-scrollbar [config]="config">Scrollable content</perfect-scrollbar>
-```
+Simply replace the element that would ordinarily be passed to `Ps.initialize` with the perfect-scollbar component. Custom configurations to override the global defaults may be passed in as a directive.
 
-```javascript
-[config]                // Custom config to override the global defaults.
+```html
+<perfect-scrollbar class="container" [config]="config">
+  <div class="content"></div>
+</perfect-scrollbar>
 ```
 
 ##### Available configuration options (custom / global configuration):


### PR DESCRIPTION
I was initially tripped up with the relationship between the component and the element that is passed to perfect-scrollbar's initialize method. This makes it clear, and beefs up the example code slightly to mirror the canonical perfect-scrollbar example https://jsfiddle.net/DanielApt/xv0rrxv3/