### PR TITLE
Optionally bind events outside of the Angular zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,14 @@ const PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = {
 Simply replace the element that would ordinarily be passed to `Ps.initialize` with the perfect-scollbar component.
 
 ```html
-<perfect-scrollbar class="container" [config]="config">
+<perfect-scrollbar class="container" [config]="config" [runOutsideAngular]="false">
   <div class="content">Scrollable content</div>
 </perfect-scrollbar>
 ```
 
 ```javascript
 [config]                // Custom config to override the global defaults.
+[runOutsideAngular]     // Set to true to prevent Angular's change detection on all events
 ```
 
 ##### Available configuration options (custom / global configuration):

--- a/src/perfect-scrollbar.component.ts
+++ b/src/perfect-scrollbar.component.ts
@@ -1,6 +1,6 @@
 import * as Ps from 'perfect-scrollbar';
 
-import { Component, DoCheck, OnDestroy, Input, Optional, ElementRef, AfterViewInit, ViewEncapsulation } from '@angular/core';
+import { Component, DoCheck, OnDestroy, Input, Optional, ElementRef, AfterViewInit, ViewEncapsulation, NgZone } from '@angular/core';
 
 import { PerfectScrollbarConfig, PerfectScrollbarConfigInterface } from './perfect-scrollbar.interfaces';
 
@@ -21,8 +21,9 @@ export class PerfectScrollbarComponent implements DoCheck, OnDestroy, AfterViewI
   private contentHeight: number;
 
   @Input() config: PerfectScrollbarConfigInterface;
+  @Input() runOutsideAngular: boolean = false;
 
-  constructor( public elementRef: ElementRef, @Optional() private defaults: PerfectScrollbarConfig ) {}
+  constructor( public elementRef: ElementRef, @Optional() private defaults: PerfectScrollbarConfig, private zone: NgZone ) {}
 
   ngDoCheck() {
     if (this.elementRef.nativeElement.children) {
@@ -53,7 +54,14 @@ export class PerfectScrollbarComponent implements DoCheck, OnDestroy, AfterViewI
 
     config.assign(this.config);
 
-    Ps.initialize(this.elementRef.nativeElement, config);
+    if (this.runOutsideAngular) {
+      this.zone.runOutsideAngular(() => {
+        Ps.initialize(this.elementRef.nativeElement, config);
+      })
+    }
+    else {
+      Ps.initialize(this.elementRef.nativeElement, config);
+    }
   }
 
   update() {


### PR DESCRIPTION
When the library is used in a component with a lot of binding, the UI sometimes exhibits staggered and lagging functionality. This allows running the perfect-scrollbar outside of the Angular zone (via setting the input parameter [runOutsideAngular]="true").