### PR TITLE
changes the way importing PerfectScrollbar object

### DIFF
--- a/src/lib/perfect-scrollbar.directive.ts
+++ b/src/lib/perfect-scrollbar.directive.ts
@@ -1,4 +1,4 @@
-import PerfectScrollbar from 'perfect-scrollbar';
+import * as PerfectScrollbar from 'perfect-scrollbar';
 
 import ResizeObserver from 'resize-observer-polyfill';
 


### PR DESCRIPTION
fixes #154

the code runs perfectly with aot compiling, but it not working with commonjs while evaluating online with plunker

related issue: https://github.com/utatti/perfect-scrollbar/issues/717