### PR TITLE
Adding peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "peerDependencies": {
     "@angular/common": ">=2.0.0",
-    "@angular/core": ">=2.0.0"
+    "@angular/core": ">=2.0.0",
+    "rxjs": "^5.5.0"
   }
 }


### PR DESCRIPTION
Hi,

I love to use this library. Recently I decided to upgrade from 2.x.x to latest supporting ng4 and I found one issue. In my dev environment I use somehow complicated flow - app parts are distributed through npms and to determine whether a dependency is a common dep or specific just to one app I use peerDependencies. Basically, if library requires any external code, this externals should be listed in `dependencies` or `peerDependencies`. Currently, `rxjs` is a "ghost dependency" - library requires it, but it is not listed in either. It will be nice to merge it also to newer versions.