### PR TITLE
Fix #262

### DIFF
--- a/src/lib/perfect-scrollbar.component.css
+++ b/src/lib/perfect-scrollbar.component.css
@@ -82,10 +82,10 @@ perfect-scrollbar > .ps {
   position: static;
 
   display: block;
-  width: inherit;
-  height: inherit;
-  max-width: inherit;
-  max-height: inherit;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 perfect-scrollbar > .ps textarea {


### PR DESCRIPTION
CSS bug: size inherit prevents using calc() on parent #262