### PR TITLE
Allow scrollToElement to accept either an HTML Element or query selector string

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ scrollToLeft(offset?, speed?)          // Animate scroll to given offset from th
 scrollToRight(offset?, speed?)         // Animate scroll to given offset from the right.
 scrollToBottom(offset?, speed?)        // Animate scroll to given offset from the bottom.
 scrollToElement(qs, offset?, speed?)   // Animate scroll to element matching query selectors.
+scrollToHtmlElement(element, offset?, speed?)   // Animate scroll to element
 ```
 
 Above functions can be accessed through the directive reference (available as directiveRef in the component). Position and offset needs to be given in pixels and speed in milliseconds.

--- a/README.md
+++ b/README.md
@@ -143,25 +143,24 @@ For more detailed documentation with all the supported events / options see the 
 ##### Available control / helper functions (provided by the directive):
 
 ```javascript
-ps()                                   // Returns reference to the PS instance.
+ps()                                        // Returns reference to the PS instance.
 
-update()                               // Updates the scrollbar size and position.
+update()                                    // Updates the scrollbar size and position.
 
-geometry(prefix)                       // Returns the geometry with specified prefix.
-position(absolute)                     // Returns the reach or absolute scroll position.
+geometry(prefix)                            // Returns the geometry with specified prefix.
+position(absolute)                          // Returns the reach or absolute scroll position.
 
-scrollable(direction)                  // Checks if the given direction is scrollable.
-                                       // Direction can be: 'any', 'both', 'x', 'y'
+scrollable(direction)                       // Checks if the given direction is scrollable.
+                                            // Direction can be: 'any', 'both', 'x', 'y'
 
-scrollTo(x, y, speed?)                 // Animate scroll to given x,y coordinates.
-scrollToY(position, speed?)            // Animate scroll to given vertical position.
-scrollToX(position, speed?)            // Animate scroll to given horizontal position.
-scrollToTop(offset?, speed?)           // Animate scroll to given offset from the top.
-scrollToLeft(offset?, speed?)          // Animate scroll to given offset from the left.
-scrollToRight(offset?, speed?)         // Animate scroll to given offset from the right.
-scrollToBottom(offset?, speed?)        // Animate scroll to given offset from the bottom.
-scrollToElement(qs, offset?, speed?)   // Animate scroll to element matching query selectors.
-scrollToHtmlElement(element, offset?, speed?)   // Animate scroll to element
+scrollTo(x, y, speed?)                      // Animate scroll to given x,y coordinates.
+scrollToY(position, speed?)                 // Animate scroll to given vertical position.
+scrollToX(position, speed?)                 // Animate scroll to given horizontal position.
+scrollToTop(offset?, speed?)                // Animate scroll to given offset from the top.
+scrollToLeft(offset?, speed?)               // Animate scroll to given offset from the left.
+scrollToRight(offset?, speed?)              // Animate scroll to given offset from the right.
+scrollToBottom(offset?, speed?)             // Animate scroll to given offset from the bottom.
+scrollToElement(element, offset?, speed?)   // Animate scroll to element (accepts an element or a query selector string).
 ```
 
 Above functions can be accessed through the directive reference (available as directiveRef in the component). Position and offset needs to be given in pixels and speed in milliseconds.

--- a/projects/lib/README.md
+++ b/projects/lib/README.md
@@ -139,25 +139,24 @@ For more detailed documentation with all the supported events / options see the 
 ##### Available control / helper functions (provided by the directive):
 
 ```javascript
-ps()                                   // Returns reference to the PS instance.
+ps()                                        // Returns reference to the PS instance.
 
-update()                               // Updates the scrollbar size and position.
+update()                                    // Updates the scrollbar size and position.
 
-geometry(prefix)                       // Returns the geometry with specified prefix.
-position(absolute)                     // Returns the reach or absolute scroll position.
+geometry(prefix)                            // Returns the geometry with specified prefix.
+position(absolute)                          // Returns the reach or absolute scroll position.
 
-scrollable(direction)                  // Checks if the given direction is scrollable.
-                                       // Direction can be: 'any', 'both', 'x', 'y'
+scrollable(direction)                       // Checks if the given direction is scrollable.
+                                            // Direction can be: 'any', 'both', 'x', 'y'
 
-scrollTo(x, y, speed?)                 // Animate scroll to given x,y coordinates.
-scrollToY(position, speed?)            // Animate scroll to given vertical position.
-scrollToX(position, speed?)            // Animate scroll to given horizontal position.
-scrollToTop(offset?, speed?)           // Animate scroll to given offset from the top.
-scrollToLeft(offset?, speed?)          // Animate scroll to given offset from the left.
-scrollToRight(offset?, speed?)         // Animate scroll to given offset from the right.
-scrollToBottom(offset?, speed?)        // Animate scroll to given offset from the bottom.
-scrollToElement(qs, offset?, speed?)   // Animate scroll to element matching query selectors.
-scrollToHtmlElement(element, offset?, speed?)   // Animate scroll to element
+scrollTo(x, y, speed?)                      // Animate scroll to given x,y coordinates.
+scrollToY(position, speed?)                 // Animate scroll to given vertical position.
+scrollToX(position, speed?)                 // Animate scroll to given horizontal position.
+scrollToTop(offset?, speed?)                // Animate scroll to given offset from the top.
+scrollToLeft(offset?, speed?)               // Animate scroll to given offset from the left.
+scrollToRight(offset?, speed?)              // Animate scroll to given offset from the right.
+scrollToBottom(offset?, speed?)             // Animate scroll to given offset from the bottom.
+scrollToElement(element, offset?, speed?)   // Animate scroll to element (accepts an element or a query selector string).
 ```
 
 Above functions can be accessed through the directive reference (available as directiveRef in the component). Position and offset needs to be given in pixels and speed in milliseconds.

--- a/projects/lib/README.md
+++ b/projects/lib/README.md
@@ -157,6 +157,7 @@ scrollToLeft(offset?, speed?)          // Animate scroll to given offset from th
 scrollToRight(offset?, speed?)         // Animate scroll to given offset from the right.
 scrollToBottom(offset?, speed?)        // Animate scroll to given offset from the bottom.
 scrollToElement(qs, offset?, speed?)   // Animate scroll to element matching query selectors.
+scrollToHtmlElement(element, offset?, speed?)   // Animate scroll to element
 ```
 
 Above functions can be accessed through the directive reference (available as directiveRef in the component). Position and offset needs to be given in pixels and speed in milliseconds.

--- a/projects/lib/src/lib/perfect-scrollbar.directive.ts
+++ b/projects/lib/src/lib/perfect-scrollbar.directive.ts
@@ -254,9 +254,7 @@ export class PerfectScrollbarDirective implements OnInit, OnDestroy, DoCheck, On
     this.animateScrolling('scrollTop', top - (offset || 0), speed);
   }
 
-  public scrollToElement(qs: string, offset?: number, speed?: number): void {
-    const element = this.elementRef.nativeElement.querySelector(qs);
-
+  public scrollToHtmlElement(element: HTMLElement, offset?: number, speed?: number): void {
     if (element) {
       const elementPos = element.getBoundingClientRect();
 
@@ -278,6 +276,11 @@ export class PerfectScrollbarDirective implements OnInit, OnDestroy, DoCheck, On
         this.animateScrolling('scrollTop', position + (offset || 0), speed);
       }
     }
+  }
+
+  public scrollToElement(qs: string, offset?: number, speed?: number): void {
+    const element = this.elementRef.nativeElement.querySelector(qs);
+    this.scrollToHtmlElement(element, offset, speed);
   }
 
   private animateScrolling(target: string, value: number, speed?: number): void {

--- a/projects/lib/src/lib/perfect-scrollbar.directive.ts
+++ b/projects/lib/src/lib/perfect-scrollbar.directive.ts
@@ -254,7 +254,11 @@ export class PerfectScrollbarDirective implements OnInit, OnDestroy, DoCheck, On
     this.animateScrolling('scrollTop', top - (offset || 0), speed);
   }
 
-  public scrollToHtmlElement(element: HTMLElement, offset?: number, speed?: number): void {
+  public scrollToElement(element: HTMLElement | string, offset?: number, speed?: number): void {
+    if (typeof element === 'string') {
+      element = this.elementRef.nativeElement.querySelector(element) as HTMLElement;
+    }
+
     if (element) {
       const elementPos = element.getBoundingClientRect();
 
@@ -276,11 +280,6 @@ export class PerfectScrollbarDirective implements OnInit, OnDestroy, DoCheck, On
         this.animateScrolling('scrollTop', position + (offset || 0), speed);
       }
     }
-  }
-
-  public scrollToElement(qs: string, offset?: number, speed?: number): void {
-    const element = this.elementRef.nativeElement.querySelector(qs);
-    this.scrollToHtmlElement(element, offset, speed);
   }
 
   private animateScrolling(target: string, value: number, speed?: number): void {


### PR DESCRIPTION
- Modified `scrollToElement()` to accept either an HTMLElement or a query selector string