### PR TITLE
Fixed Nested Native Scroll Issue

### DIFF
--- a/projects/lib/src/lib/perfect-scrollbar-force-native-scroll.directive.ts
+++ b/projects/lib/src/lib/perfect-scrollbar-force-native-scroll.directive.ts
@@ -1,0 +1,13 @@
+import { Directive, ElementRef, Renderer2 } from '@angular/core';
+
+@Directive({
+  selector: '[forceNativeScrolling]'
+})
+export class ForceNativeScrollDirective {
+
+  constructor(private renderer: Renderer2, el: ElementRef) {
+    ['ps__child', 'ps__child--consume'].forEach((className) => {
+      this.renderer.addClass(el?.nativeElement, className);
+    });
+  }
+}

--- a/projects/lib/src/lib/perfect-scrollbar.module.ts
+++ b/projects/lib/src/lib/perfect-scrollbar.module.ts
@@ -3,11 +3,12 @@ import { CommonModule } from '@angular/common';
 
 import { PerfectScrollbarComponent } from './perfect-scrollbar.component';
 import { PerfectScrollbarDirective } from './perfect-scrollbar.directive';
+import { ForceNativeScrollDirective } from './perfect-scrollbar-force-native-scroll.directive';
 
 @NgModule({
     imports: [CommonModule],
-    declarations: [PerfectScrollbarComponent, PerfectScrollbarDirective],
-    exports: [CommonModule, PerfectScrollbarComponent, PerfectScrollbarDirective]
+    declarations: [PerfectScrollbarComponent, PerfectScrollbarDirective, ForceNativeScrollDirective],
+    exports: [CommonModule, PerfectScrollbarComponent, PerfectScrollbarDirective, ForceNativeScrollDirective]
 })
 export class PerfectScrollbarModule {
 }


### PR DESCRIPTION
Native Scrollbars does not by default inside of perfect-scrollbar. The support for classes was added to perfect-scrollbar as mentioned in issue [#577](https://github.com/mdbootstrap/perfect-scrollbar/issues/577#issuecomment-333747703) 

This PR will extend the behavior and simplify adding classes using `[forceNativeScrolling]` directive on the overflowed element.

Issue Repro Link: https://stackblitz.com/edit/angular-hrdxrj

Example Usage of Directive is shown in attached file:

[ForcedNativeScrollingDemo.txt](https://github.com/zefoy/ngx-perfect-scrollbar/files/6392152/ForcedNativeScrollingDemo.txt)
